### PR TITLE
Fixes to batch scripts

### DIFF
--- a/DataProduction/batch/generator_SLHC.sh
+++ b/DataProduction/batch/generator_SLHC.sh
@@ -166,7 +166,7 @@ sed "s#PUFILEA#$TOP/MBiasSample.root#"                 -i BH_dummy.py
 sed "s/TILTEDORFLAT/$GEOM/"                            -i BH_dummy2.py
 sed "s/MYGLOBALTAG/$GTAG/"                             -i BH_dummy2.py
 
-perl -i.bak -pe 's/SWTUNING/'"${SWTUN}"'/g' BH_dummy.py
+perl -i.bak -pe 's@SWTUNING@'"${SWTUN}"'@g' BH_dummy.py
 
 if [ "$BANK" -eq 1 ]; then
     sed "s/NEVTS/$EVTS/"                                   -i BH_dummy2.py

--- a/DataProduction/batch/launch_SLHC.sh
+++ b/DataProduction/batch/launch_SLHC.sh
@@ -49,9 +49,8 @@
 # You have to adapt this to the storage element you plan to use
 
 # Info concerning the grid directory where the data will be stored
-export LFC_HOST=osg-se.sprace.org.br
-STORAGEDIR=/cms/store/user/calligar/phase2_tracker_simulation/data/SebViret_HLLHCTuto920/20180629_ttbarpu200_32000evts
-
+export LFC_HOST=lyogrid06.in2p3.fr
+STORAGEDIR=/dpm/in2p3.fr/home/cms/data/store/user/sviret/SLHC/GEN
 
 # The queue over which you want to send the job
 BQUEUE=1nd

--- a/DataProduction/batch/launch_SLHC.sh
+++ b/DataProduction/batch/launch_SLHC.sh
@@ -49,14 +49,15 @@
 # You have to adapt this to the storage element you plan to use
 
 # Info concerning the grid directory where the data will be stored
-export LFC_HOST=lyogrid06.in2p3.fr
-STORAGEDIR=/dpm/in2p3.fr/home/cms/data/store/user/sviret/SLHC/GEN 
+export LFC_HOST=osg-se.sprace.org.br
+STORAGEDIR=/cms/store/user/calligar/phase2_tracker_simulation/data/SebViret_HLLHCTuto920/20180629_ttbarpu200_32000evts
+
 
 # The queue over which you want to send the job
 BQUEUE=1nd
 
 # The directory GRID-friendly address
-STORAGEDIR2=srm://$LFC_HOST/$STORAGEDIR                            
+STORAGEDIR2=gsiftp://$LFC_HOST/$STORAGEDIR
 
 ###########################################################
 ###########################################################
@@ -142,7 +143,7 @@ TID=${11}
 THRESH=${12}
 
 DIRNAME=${MATTER}_PU${NPU}_${GTYPE}_${13}
-
+LOGNAME=${MATTER}_PU${NPU}_${GTYPE}_${13}
 # Then we setup some environment variables
 
 cd  ..
@@ -159,7 +160,7 @@ echo 'Creating directory '$STORAGEDIR/$DIRNAME' for type '$PTYPE
 OUTPUTDIR=$STORAGEDIR2/$DIRNAME
 OUTPUTDIR2=$STORAGEDIR/$DIRNAME
 
-gfal-mkdir $OUTPUTDIR
+gfal-mkdir -p $OUTPUTDIR
 
 # Special case, rerun the stub production on relval sample
 
@@ -192,7 +193,7 @@ if [ $MATTER == "SWTUNING" ]; then
 	    chmod 755 gen_job_${DIRNAME}_${i}.sh
 
 	    if [ ${16} == "BATCH" ]; then	
-		bsub -q $BQUEUE -e /dev/null -o /tmp/${LOGNAME}_out.txt gen_job_${DIRNAME}_${i}.sh
+		bsub -q $BQUEUE -e /tmp/$(whoami)_${LOGNAME}_err.txt -o /tmp/$(whoami)_${LOGNAME}_out.txt gen_job_${DIRNAME}_${i}.sh
 	    fi
 
 	    i=$(( $i + 1))
@@ -223,7 +224,7 @@ do
     chmod 755 gen_job_${DIRNAME}_${i}.sh
 
     if [ ${16} == "BATCH" ]; then	
-	bsub -q $BQUEUE -e /dev/null -o /tmp/${LOGNAME}_out.txt gen_job_${DIRNAME}_${i}.sh
+	bsub -q $BQUEUE -e /tmp/$(whoami)_${LOGNAME}_err.txt -o /tmp/$(whoami)_${LOGNAME}_out.txt gen_job_${DIRNAME}_${i}.sh
     fi
 
     i=$(( $i + 1))


### PR DESCRIPTION
Fix perl substitution control character:
the slash in "2 GeV/c" was misinterpreted as a control character. Changed the latter to "@"

Change srm to gsiftp:
It's the native protocol for gfal-mkdir and gfal-cp, while srm works only for some sites

Define LOGNAME:
It was used but not defined

Allow gfal-mkdir to create parent directories:
It would fail otherwise and not create the directory

Dump stderr to log:
it was redirected to /dev/null before